### PR TITLE
Require base Active Support library before specific extensions

### DIFF
--- a/lib/invisible_ink.rb
+++ b/lib/invisible_ink.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require_relative "invisible_ink/version"
+require "active_support"
 require "active_support/encrypted_file"
 require "securerandom"
 require "shellwords"


### PR DESCRIPTION
Solution for issue #4 